### PR TITLE
fix(docs): adjust module install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Wenn du meine Arbeit schätzt, dann freue ich mich über einen bescheidenen Beit
 
 2. Wechsle nun in das MMM-NINA Modul Verzeichnis und führe darin folgendes Kommando aus, um die Dependencies zu installieren:
    ```bash
-   npm install --only=production
+   npm ci --production
    ```
 3. Ermittle den amtlichen Gemeindeschlüssel deines Ortes aus [dieser Liste](https://www.xrepository.de/api/xrepository/urn:de:bund:destatis:bevoelkerungsstatistik:schluessel:rs_2021-07-31/download/Regionalschl_ssel_2021-07-31.json).
 


### PR DESCRIPTION
As there is a `package-lock.json` checked-in, it would be better to use the `npm ci` command to just install the packages mentioned in there. 
Also this avoids situations where you need to reset the `package-lock.json` file before you can pull in changes from the repository.